### PR TITLE
handle single navigation expand filter

### DIFF
--- a/OData/src/System.Web.OData/OData/EnableQueryAttribute.cs
+++ b/OData/src/System.Web.OData/OData/EnableQueryAttribute.cs
@@ -162,6 +162,23 @@ namespace System.Web.OData
         }
 
         /// <summary>
+        /// Honor $filter inside $expand of non-collection navigation property.
+        /// The expanded property is only populated when the filter evaluates to true.
+        /// This setting is false by default.
+        /// </summary>
+        public bool HandleReferenceNavigationPropertyExpandFilter
+        {
+            get
+            {
+                return _querySettings.HandleReferenceNavigationPropertyExpandFilter;
+            }
+            set
+            {
+                _querySettings.HandleReferenceNavigationPropertyExpandFilter = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the query parameters that are allowed in queries.
         /// </summary>
         /// <value>The default includes all query options: $filter, $skip, $top, $orderby, $expand, $select, $count,

--- a/OData/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
+++ b/OData/src/System.Web.OData/OData/Query/Expressions/SelectExpandBinder.cs
@@ -191,9 +191,11 @@ namespace System.Web.OData.Query.Expressions
             Type nullablePropertyType = propertyValue.Type.ToNullable();
             Expression nullablePropertyValue = ExpressionHelpers.ToNullable(propertyValue);
 
-            if (filterClause != null && property.Type.IsCollection())
+            if (filterClause != null)
             {
-                IEdmTypeReference edmElementType = property.Type.AsCollection().ElementType();
+                var collection = property.Type.IsCollection();
+
+                IEdmTypeReference edmElementType = (collection ? property.Type.AsCollection().ElementType() : property.Type);
                 Type clrElementType = EdmLibHelpers.GetClrType(edmElementType, _model);
                 if (clrElementType == null)
                 {
@@ -201,20 +203,52 @@ namespace System.Web.OData.Query.Expressions
                         edmElementType.FullName()));
                 }
 
-                Expression filterSource =
-                    typeof(IEnumerable).IsAssignableFrom(source.Type.GetProperty(propertyName).PropertyType)
-                        ? Expression.Call(
-                            ExpressionHelperMethods.QueryableAsQueryable.MakeGenericMethod(clrElementType),
-                            nullablePropertyValue)
-                        : nullablePropertyValue;
-                // TODO: Implement proper support for $select/$expand after $apply
-                Expression filterPredicate = FilterBinder.Bind(null, filterClause, clrElementType, _context.RequestContainer);
-                MethodCallExpression filterResult = Expression.Call(
-                    ExpressionHelperMethods.QueryableWhereGeneric.MakeGenericMethod(clrElementType),
-                    filterSource,
-                    filterPredicate);
+                Expression filterResult = nullablePropertyValue;
 
-                nullablePropertyType = filterResult.Type;
+                if (collection)
+                {
+                    Expression filterSource =
+                        typeof(IEnumerable).IsAssignableFrom(source.Type.GetProperty(propertyName).PropertyType)
+                            ? Expression.Call(
+                                ExpressionHelperMethods.QueryableAsQueryable.MakeGenericMethod(clrElementType),
+                                nullablePropertyValue)
+                            : nullablePropertyValue;
+                    
+                    // TODO: Implement proper support for $select/$expand after $apply
+                    Expression filterPredicate = FilterBinder.Bind(null, filterClause, clrElementType, _context.RequestContainer);
+                    filterResult = Expression.Call(
+                        ExpressionHelperMethods.QueryableWhereGeneric.MakeGenericMethod(clrElementType),
+                        filterSource,
+                        filterPredicate);
+
+                    nullablePropertyType = filterResult.Type;
+                }
+                else if(_settings.HandleReferenceNavigationPropertyExpandFilter)
+                {                    
+                    var filterLambdaExpression = FilterBinder.Bind(null, filterClause, clrElementType, _context.RequestContainer) as LambdaExpression;
+                    if(filterLambdaExpression == null)
+                    {
+                        throw new ODataException(Error.Format(SRResources.ExpandFilterExpressionNotLambdaExpression,
+                            property.Name, nameof(LambdaExpression)));
+                    }
+
+                    var filterParameter = filterLambdaExpression.Parameters.FirstOrDefault();
+                    if(filterParameter == null)
+                    {   
+                        //Never seen this, but just to be safe...
+                        throw new ODataException(Error.Format(SRResources.ExpandFilterExpressionLambdaExpressionNoParameter,
+                            property.Name));                            
+                    }
+
+                    var predicateExpression = new ReferenceNavigationPropertyExpandFilterVisitor(filterParameter, nullablePropertyValue).Visit(filterLambdaExpression.Body);
+
+                    // predicateExpression == true ? nullablePropertyValue : null
+                    filterResult = Expression.Condition(
+                        test: predicateExpression,
+                        ifTrue: nullablePropertyValue,
+                        ifFalse: Expression.Constant(value: null, type: nullablePropertyType));
+                }
+
                 if (_settings.HandleNullPropagation == HandleNullPropagationOption.True)
                 {
                     // nullablePropertyValue == null ? null : filterResult
@@ -244,6 +278,28 @@ namespace System.Web.OData.Query.Expressions
             }
 
             return propertyValue;
+        }
+
+        private class ReferenceNavigationPropertyExpandFilterVisitor : ExpressionVisitor
+        {
+            private Expression _source;
+            private ParameterExpression _parameterExpression;
+
+            public ReferenceNavigationPropertyExpandFilterVisitor(ParameterExpression parameterExpression, Expression source)
+            {
+                _source = source;
+                _parameterExpression = parameterExpression;
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                if(node != _parameterExpression)
+                {
+                    throw new ODataException(Error.Format(SRResources.ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter, node.Name));
+                }
+
+                return _source;
+            }
         }
 
         // Generates the expression

--- a/OData/src/System.Web.OData/OData/Query/ODataQuerySettings.cs
+++ b/OData/src/System.Web.OData/OData/Query/ODataQuerySettings.cs
@@ -118,6 +118,16 @@ namespace System.Web.OData.Query
             get; set;
         }
 
+        /// <summary>
+        /// Honor $filter inside $expand of non-collection navigation property.
+        /// The expanded property is only populated when the filter evaluates to true.
+        /// This setting is false by default.
+        /// </summary>
+        public bool HandleReferenceNavigationPropertyExpandFilter
+        {
+            get; set;
+        }
+
         internal void CopyFrom(ODataQuerySettings settings)
         {
             EnsureStableOrdering = settings.EnsureStableOrdering;
@@ -125,6 +135,7 @@ namespace System.Web.OData.Query
             HandleNullPropagation = settings.HandleNullPropagation;
             PageSize = settings.PageSize;
             ModelBoundPageSize = settings.ModelBoundPageSize;
+            HandleReferenceNavigationPropertyExpandFilter = settings.HandleReferenceNavigationPropertyExpandFilter;
         }
     }
 }

--- a/OData/src/System.Web.OData/Properties/SRResources.Designer.cs
+++ b/OData/src/System.Web.OData/Properties/SRResources.Designer.cs
@@ -673,6 +673,24 @@ namespace System.Web.OData.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The generated lambda expression of $filter in $expand of reference navigation property &apos;{0}&apos; has no parameter..
+        /// </summary>
+        internal static string ExpandFilterExpressionLambdaExpressionNoParameter {
+            get {
+                return ResourceManager.GetString("ExpandFilterExpressionLambdaExpressionNoParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to $filter in $expand of reference navigation property &apos;{0}&apos; is not expected type &apos;{1}&apos;.
+        /// </summary>
+        internal static string ExpandFilterExpressionNotLambdaExpression {
+            get {
+                return ResourceManager.GetString("ExpandFilterExpressionNotLambdaExpression", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot create an EDM model as the action &apos;{0}&apos; on controller &apos;{1}&apos; has a void return type..
         /// </summary>
         internal static string FailedToBuildEdmModelBecauseReturnTypeIsNull {
@@ -1848,6 +1866,15 @@ namespace System.Web.OData.Properties {
         internal static string RecursiveComplexTypesNotAllowed {
             get {
                 return ResourceManager.GetString("RecursiveComplexTypesNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found unexpected parameter &apos;{0}&apos;..
+        /// </summary>
+        internal static string ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter {
+            get {
+                return ResourceManager.GetString("ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter", resourceCulture);
             }
         }
         

--- a/OData/src/System.Web.OData/Properties/SRResources.resx
+++ b/OData/src/System.Web.OData/Properties/SRResources.resx
@@ -868,4 +868,13 @@
   <data name="PropertyOrPathWasRemovedFromContext" xml:space="preserve">
     <value>Property or path {0} isn't available in the current context. It was removed in earlier transformation.</value>
   </data>
+  <data name="ExpandFilterExpressionLambdaExpressionNoParameter" xml:space="preserve">
+    <value>The generated lambda expression of $filter in $expand of reference navigation property '{0}' has no parameter.</value>
+  </data>
+  <data name="ExpandFilterExpressionNotLambdaExpression" xml:space="preserve">
+    <value>$filter in $expand of reference navigation property '{0}' is not expected type '{1}'</value>
+  </data>
+  <data name="ReferenceNavigationPropertyExpandFilterVisitorUnexpectedParameter" xml:space="preserve">
+    <value>Found unexpected parameter '{0}'.</value>
+  </data>
 </root>

--- a/OData/test/E2ETest/WebStack.QA.Test.OData/QueryComposition/SelectExpandTests.cs
+++ b/OData/test/E2ETest/WebStack.QA.Test.OData/QueryComposition/SelectExpandTests.cs
@@ -28,7 +28,8 @@ namespace WebStack.QA.Test.OData.QueryComposition
                   typeof(IAssembliesResolver),
                   new TestAssemblyResolver(
                       typeof(SelectCustomerController),
-                      typeof(EFSelectCustomersController)));
+                      typeof(EFSelectCustomersController),
+                      typeof(EFSelectOrdersController)));
             configuration.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
             configuration.Formatters.JsonFormatter.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
             configuration.Count().Filter().OrderBy().Expand().MaxTop(null).Select();
@@ -50,6 +51,7 @@ namespace WebStack.QA.Test.OData.QueryComposition
             builder.EntitySet<SelectOrder>("SelectOrder");
             builder.EntitySet<SelectBonus>("SelectBonus");
             builder.Action("ResetDataSource");
+            builder.Action("ResetDataSource-Order");
 
             IEdmModel model = builder.GetEdmModel();
             return model;
@@ -301,7 +303,7 @@ namespace WebStack.QA.Test.OData.QueryComposition
             request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
             HttpClient client = new HttpClient();
             HttpResponseMessage response;
-           
+
             response = client.SendAsync(request).Result;
 
             Assert.NotNull(response);
@@ -341,13 +343,46 @@ namespace WebStack.QA.Test.OData.QueryComposition
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(response.Content);
-            
+
             var responseObject = JObject.Parse(response.Content.ReadAsStringAsync().Result);
             var result = responseObject["value"] as JArray;
             var expandProp = result[0]["SelectOrders"] as JArray;
             Assert.Equal(expandProp.Count, 2);
             Assert.Equal(expandProp[0]["Id"], 1);
             Assert.Equal(expandProp[1]["Id"], 2);
+        }
+
+        [Fact]
+        public void QueryForAnEntryWithExpandSingleNavigationPropertyFilterWorks()
+        {
+            RestoreData("-Order");
+            HttpClient client = new HttpClient();
+            HttpResponseMessage response;
+
+            // Arrange
+            Func<string, JArray> TestBody = (url) =>
+            {
+                string queryUrl = url;
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, queryUrl);
+                request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json;odata.metadata=none"));
+                
+                // Act
+                response = client.SendAsync(request).Result;
+
+                // Assert
+                Assert.NotNull(response);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.NotNull(response.Content);
+
+                var responseObject = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+                return responseObject["value"] as JArray;
+            };
+
+            var result = TestBody(string.Format("{0}/selectexpand/EFSelectOrders?$expand=SelectCustomer($filter=Id ne 1)", BaseAddress));
+            Assert.False(result[0]["SelectCustomer"].HasValues);
+
+            result = TestBody(string.Format("{0}/selectexpand/EFSelectOrders?$expand=SelectCustomer($filter=Id eq 1)", BaseAddress));
+            Assert.Equal(1, (int)result[0]["SelectCustomer"]["Id"]);
         }
 
         [Fact]
@@ -541,7 +576,7 @@ namespace WebStack.QA.Test.OData.QueryComposition
 
             // Act
             HttpResponseMessage response = client.SendAsync(request).Result;
-                                                                                                                                                                                                                                                                                                                                                    
+
             // Assert
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -584,9 +619,9 @@ namespace WebStack.QA.Test.OData.QueryComposition
             Assert.Equal(expandProp[0]["Id"], 2);
         }
 
-        private void RestoreData()
+        private void RestoreData(string suffix = null)
         {
-            string requestUri = BaseAddress + "/selectexpand/ResetDataSource";
+            string requestUri = BaseAddress + $"/selectexpand/ResetDataSource{suffix}";
             HttpClient client = new HttpClient();
             HttpResponseMessage response = client.GetAsync(requestUri).Result;
             response.EnsureSuccessStatusCode();
@@ -721,8 +756,48 @@ namespace WebStack.QA.Test.OData.QueryComposition
         }
     }
 
+    public class EFSelectOrdersController : ODataController
+    {
+        private readonly SampleContext _db = new SampleContext();
+
+        [EnableQuery(HandleReferenceNavigationPropertyExpandFilter = true)]
+        public IHttpActionResult Get()
+        {
+            return Ok(_db.Orders);
+        }
+
+        [HttpGet]
+        [ODataRoute("ResetDataSource-Order")]
+        public IHttpActionResult ResetDataSource()
+        {
+            if (_db.Database.Exists())
+            {
+                _db.Database.Delete();
+                _db.Database.Create();
+            }
+
+            Generate();
+            return Ok();
+        }
+
+        public void Generate()
+        {
+            var order = new EFSelectOrder
+            {
+                Id = 1,
+                SelectCustomer = new EFSelectCustomer
+                {
+                    Id = 1
+                }
+            };
+            _db.Orders.Add(order);
+            _db.SaveChanges();
+        }
+    }
+
     public class SampleContext : DbContext
     {
+        //todo: do not checkin
         public static string ConnectionString = @"Data Source=(LocalDb)\v11.0;Integrated Security=True;Initial Catalog=SelectExpandTest";
 
         public SampleContext()
@@ -733,6 +808,8 @@ namespace WebStack.QA.Test.OData.QueryComposition
         public DbSet<EFSelectCustomer> Customers { get; set; }
 
         public DbSet<SelectCustomer> SelectCustomers { get; set; }
+
+        public DbSet<EFSelectOrder> Orders { get; set; }
     }
 
     public class EFSelectCustomer
@@ -744,6 +821,7 @@ namespace WebStack.QA.Test.OData.QueryComposition
     public class EFSelectOrder
     {
         public int Id { get; set; }
+        public virtual EFSelectCustomer SelectCustomer { get; set; }
     }
 
     public class SelectCustomer

--- a/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
+++ b/OData/test/UnitTest/System.Web.OData.Test/OData/Query/Expressions/SelectExpandBinderTest.cs
@@ -534,7 +534,7 @@ namespace System.Web.OData.Query.Expressions
         }
 
         [Fact]
-        public void CreatePropertyValueExpressionWithFilter_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
+        public void CreatePropertyValueExpressionWithFilter_Collection_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
         {
             // Arrange
             _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.Order, value: null);
@@ -554,7 +554,7 @@ namespace System.Web.OData.Query.Expressions
         }
 
         [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Works_HandleNullPropagationOptionIsTrue()
+        public void CreatePropertyValueExpressionWithFilter_Collection_Works_HandleNullPropagationOptionIsTrue()
         {
             // Arrange
             _model.Model.SetAnnotationValue(_model.Order, new ClrTypeAnnotation(typeof(Order)));
@@ -590,7 +590,7 @@ namespace System.Web.OData.Query.Expressions
         }
 
         [Fact]
-        public void CreatePropertyValueExpressionWithFilter_Works_HandleNullPropagationOptionIsFalse()
+        public void CreatePropertyValueExpressionWithFilter_Collection_Works_HandleNullPropagationOptionIsFalse()
         {
             // Arrange
             _model.Model.SetAnnotationValue(_model.Order, new ClrTypeAnnotation(typeof(Order)));
@@ -622,6 +622,137 @@ namespace System.Web.OData.Query.Expressions
             var orders = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as IEnumerable<Order>;
             Assert.Single(orders);
             Assert.Equal(1, orders.ToList()[0].ID);
+        }
+
+        [Fact]
+        public void CreatePropertyValueExpressionWithFilter_Single_ThrowsODataException_IfMappingTypeIsNotFoundInModel()
+        {
+            // Arrange
+            _model.Model.SetAnnotationValue<ClrTypeAnnotation>(_model.Customer, value: null);
+            _settings.HandleReferenceNavigationPropertyExpandFilter = true;
+            var order = Expression.Constant(new Order());
+            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+
+            var parser = new ODataQueryOptionParser(
+                _model.Model,
+                _model.Customer,
+                _model.Customers,
+                new Dictionary<string, string> { { "$filter", "ID eq 1" } });
+            var filterCaluse = parser.ParseFilter();
+
+            // Act & Assert
+            Assert.Throws<ODataException>(
+                () => _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, filterCaluse),
+                "The provided mapping does not contain a resource for the resource type 'NS.Customer'.");
+        }
+
+        [Fact]
+        public void CreatePropertyValueExpressionWithFilter_Single_Works_IfSettingIsOff()
+        {
+            // Arrange
+            _settings.HandleReferenceNavigationPropertyExpandFilter = false;
+            var order = Expression.Constant(
+                    new Order
+                    {
+                        Customer = new Customer
+                        {
+                            ID = 1
+                        }
+                    }
+            );
+            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+
+            var parser = new ODataQueryOptionParser(
+                _model.Model,
+                _model.Customer,
+                _model.Customers,
+                new Dictionary<string, string> { { "$filter", "ID ne 1" } });
+            var filterCaluse = parser.ParseFilter();
+
+            // Act 
+            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, filterCaluse);
+
+            // Assert            
+            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as Customer;
+            Assert.NotNull(customer);
+            Assert.Equal(1, customer.ID);
+        }
+
+        [Fact]
+        public void CreatePropertyValueExpressionWithFilter_Single_Works_HandleNullPropagationOptionIsTrue()
+        {
+            // Arrange
+            _settings.HandleReferenceNavigationPropertyExpandFilter = true;
+            _settings.HandleNullPropagation = HandleNullPropagationOption.True;
+            var order = Expression.Constant(
+                    new Order
+                    {
+                        Customer = new Customer
+                        {
+                            ID = 1
+                        }
+                    }
+            );
+            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+
+            var parser = new ODataQueryOptionParser(
+                _model.Model,
+                _model.Customer,
+                _model.Customers,
+                new Dictionary<string, string> { { "$filter", "ID ne 1" } });
+            var filterCaluse = parser.ParseFilter();
+
+            // Act
+            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, filterCaluse);
+            
+            // Assert
+            Assert.Equal(
+                string.Format(
+                    "IIF((value({0}) == null), null, IIF((value({0}).Customer == null), null, " +
+                    "IIF((value({0}).Customer.ID != value(System.Web.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty), " +
+                    "value({0}).Customer, null)))",
+                    order.Type),
+                filterInExpand.ToString());
+            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as Customer;
+            Assert.Null(customer);
+        }
+
+        [Fact]
+        public void CreatePropertyValueExpressionWithFilter_Single_Works_HandleNullPropagationOptionIsFalse()
+        {
+            // Arrange
+            _settings.HandleReferenceNavigationPropertyExpandFilter = true;
+            _settings.HandleNullPropagation = HandleNullPropagationOption.False;
+            var order = Expression.Constant(
+                    new Order
+                    {
+                        Customer = new Customer
+                        {
+                            ID = 1
+                        }
+                    }
+            );
+            var customerProperty = _model.Order.NavigationProperties().Single(p => p.Name == "Customer");
+
+            var parser = new ODataQueryOptionParser(
+                _model.Model,
+                _model.Customer,
+                _model.Customers,
+                new Dictionary<string, string> { { "$filter", "ID ne 1" } });
+            var filterCaluse = parser.ParseFilter();
+
+            // Act
+            var filterInExpand = _binder.CreatePropertyValueExpressionWithFilter(_model.Order, customerProperty, order, filterCaluse);
+
+            // Assert
+            Assert.Equal(
+                string.Format(
+                    "IIF((value({0}).Customer.ID != value(System.Web.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.Int32]).TypedProperty), " +
+                    "value({0}).Customer, null)",
+                    order.Type),
+                filterInExpand.ToString());
+            var customer = Expression.Lambda(filterInExpand).Compile().DynamicInvoke() as Customer;
+            Assert.Null(customer);
         }
 
         [Fact]


### PR DESCRIPTION
### Description
Today nested $filter inside $expand of non-collection navigation property is ignored. This change introduces a ODataQuerySettings that honor the $filter. If the condition is not met, the navigation property returns null.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
