### PR TITLE
Fix unsafe dictionary

### DIFF
--- a/src/System.Web.OData/OData/Builder/Conventions/Attributes/AttributeConvention.cs
+++ b/src/System.Web.OData/OData/Builder/Conventions/Attributes/AttributeConvention.cs
@@ -63,8 +63,11 @@ namespace System.Web.OData.Builder.Conventions.Attributes
                 .OfType<Attribute>()
                 .ToList();
 
-                // It's OK to replace it someone else already added 
-                attributesCache[member] = attributes; 
+                lock(attributesCache) // prevent concurrent writes which can result in NullReferenceExceptions in Dictionary
+                {
+                    // It's OK to replace it someone else already added 
+                    attributesCache[member] = attributes; 
+                }
             }
 
              attributes = attributes

--- a/src/System.Web.OData/OData/Builder/Conventions/Attributes/AttributeConvention.cs
+++ b/src/System.Web.OData/OData/Builder/Conventions/Attributes/AttributeConvention.cs
@@ -56,14 +56,21 @@ namespace System.Web.OData.Builder.Conventions.Attributes
 
 
             ICollection<Attribute> attributes;
-            if (!attributesCache.TryGetValue(member, out attributes))
+            boolean cacheHit = false;
+
+            lock(attributesCache) // isolate access to cache
+            {
+                cacheHit = attributesCache.TryGetValue(member, out attributes));
+            }
+
+            if (!cacheHit)
             {
                 attributes = member
                 .GetCustomAttributes(inherit: true)
                 .OfType<Attribute>()
                 .ToList();
 
-                lock(attributesCache) // prevent concurrent writes which can result in NullReferenceExceptions in Dictionary
+                lock(attributesCache) // isolate access to cache
                 {
                     // It's OK to replace it someone else already added 
                     attributesCache[member] = attributes; 


### PR DESCRIPTION
This should fix the occasional NullReferenceException we are seeing in the Dictionary`2.Insert method, which is associated with concurrency issues. This approach is more efficient than using a ConcurrentDictionary