### PR TITLE
Special case for Auto selecte on type level

### DIFF
--- a/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
+++ b/src/System.Web.OData/OData/Formatter/EdmLibHelpers.cs
@@ -914,7 +914,7 @@ namespace System.Web.OData.Formatter
             return mergedQuerySettings;
         }
 
-        private static ModelBoundQuerySettings GetModelBoundQuerySettings<T>(T key, IEdmModel edmModel,
+        internal static ModelBoundQuerySettings GetModelBoundQuerySettings<T>(T key, IEdmModel edmModel,
             DefaultQuerySettings defaultQuerySettings = null)
             where T : IEdmElement
         {

--- a/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
+++ b/src/System.Web.OData/OData/Query/ODataQueryOptions.cs
@@ -704,6 +704,10 @@ namespace System.Web.OData.Query
                     autoExpandRawValue,
                     Context,
                     _queryOptionParser);
+
+                var typeLevelModelSettings = EdmLibHelpers.GetModelBoundQuerySettings(this.Context.ElementType, this.Context.Model, this.Context.DefaultQuerySettings);
+                SelectExpand.SelectExpandClause.AllAutoSelected = (typeLevelModelSettings != null && typeLevelModelSettings.DefaultSelectType == SelectExpandType.Automatic);
+
                 if (originalSelectExpand != null && originalSelectExpand.LevelsMaxLiteralExpansionDepth > 0)
                 {
                     SelectExpand.LevelsMaxLiteralExpansionDepth = originalSelectExpand.LevelsMaxLiteralExpansionDepth;

--- a/src/System.Web.OData/OData/Query/SelectExpandQueryOption.cs
+++ b/src/System.Web.OData/OData/Query/SelectExpandQueryOption.cs
@@ -135,8 +135,6 @@ namespace System.Web.OData.Query
                 if (_selectExpandClause == null)
                 {
                     _selectExpandClause = _queryOptionParser.ParseSelectAndExpand();
-                    var typeLevelModelSettings = EdmLibHelpers.GetModelBoundQuerySettings(this.Context.ElementType, this.Context.Model, this.Context.DefaultQuerySettings);
-                    _selectExpandClause.AllAutoSelected = (typeLevelModelSettings != null && typeLevelModelSettings.DefaultSelectType == SelectExpandType.Automatic);
                 }
 
                 return _selectExpandClause;

--- a/src/System.Web.OData/OData/Query/SelectExpandQueryOption.cs
+++ b/src/System.Web.OData/OData/Query/SelectExpandQueryOption.cs
@@ -135,6 +135,8 @@ namespace System.Web.OData.Query
                 if (_selectExpandClause == null)
                 {
                     _selectExpandClause = _queryOptionParser.ParseSelectAndExpand();
+                    var typeLevelModelSettings = EdmLibHelpers.GetModelBoundQuerySettings(this.Context.ElementType, this.Context.Model, this.Context.DefaultQuerySettings);
+                    _selectExpandClause.AllAutoSelected = (typeLevelModelSettings != null && typeLevelModelSettings.DefaultSelectType == SelectExpandType.Automatic);
                 }
 
                 return _selectExpandClause;
@@ -280,7 +282,7 @@ namespace System.Web.OData.Query
             }
             else if (levelsEncountered)
             {
-                return new SelectExpandClause(selectItems, selectExpandClause.AllSelected);
+                return new SelectExpandClause(selectItems, selectExpandClause.AllSelected, selectExpandClause.AllAutoSelected);
             }
             else
             {
@@ -532,6 +534,8 @@ namespace System.Web.OData.Query
             List<SelectItem> autoExpandItems = new List<SelectItem>(originAutoExpandItems);
             bool hasAutoSelectExpandInExpand = (originAutoSelectItems.Count() + originAutoExpandItems.Count() != 0);
             bool allSelected = originAutoSelectItems.Count == 0 && selectExpandClause.AllSelected;
+            var typeLevelSettings = EdmLibHelpers.GetModelBoundQuerySettings(entityType, this.Context.Model, this.Context.DefaultQuerySettings);
+            bool allAutoSelected = (typeLevelSettings != null && typeLevelSettings.DefaultSelectType == SelectExpandType.Automatic);
 
             while (level > 0)
             {
@@ -543,7 +547,8 @@ namespace System.Web.OData.Query
                         currentSelectExpandClause = new SelectExpandClause(
                             new SelectItem[] { }.Concat(selectExpandClause.SelectedItems)
                                 .Concat(originAutoSelectItems).Concat(autoExpandItems),
-                            allSelected);
+                            allSelected,
+                            allAutoSelected);
                     }
                     else
                     {
@@ -556,7 +561,8 @@ namespace System.Web.OData.Query
                     currentSelectExpandClause = new SelectExpandClause(
                         new SelectItem[] { item }.Concat(selectExpandClause.SelectedItems)
                             .Concat(originAutoSelectItems).Concat(autoExpandItems),
-                        allSelected);
+                        allSelected,
+                        allAutoSelected);
                 }
                 else
                 {
@@ -570,7 +576,8 @@ namespace System.Web.OData.Query
                         new SelectItem[] { }.Concat(selectExpandClause.SelectedItems)
                             .Concat(items)
                             .Concat(originAutoSelectItems).Concat(autoExpandItems),
-                        allSelected);
+                        allSelected,
+                        allAutoSelected);
                 }
 
                 // Construct a new ExpandedNavigationSelectItem with current SelectExpandClause.

--- a/test/UnitTest/System.Web.OData.Test/OData/SelectExpandTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/SelectExpandTest.cs
@@ -95,6 +95,24 @@ namespace System.Web.OData
             Assert.Equal("http://localhost/odata-autoselect/$metadata#SelectExpandTestCustomers", result["@odata.context"]);
         }
 
+
+        [Fact]
+        public void ExplicitSelectHasPriorityToAutoSelect()
+        {
+            // Arrange
+            string uri = "/odata-autoselect/SelectExpandTestCustomers?$select=ID";
+
+            // Act
+            HttpResponseMessage response = GetResponse(uri, AcceptJsonFullMetadata);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            JObject result = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+            Console.WriteLine(result["@odata.context"]);
+            Assert.Equal("http://localhost/odata-autoselect/$metadata#SelectExpandTestCustomers(ID)", result["@odata.context"]);
+        }
+
         [Fact]
         public void AutoSelectDoesntAddToContextForExpanded()
         {
@@ -110,6 +128,23 @@ namespace System.Web.OData
             JObject result = JObject.Parse(response.Content.ReadAsStringAsync().Result);
             Console.WriteLine(result["@odata.context"]);
             Assert.Equal("http://localhost/odata-autoselect/$metadata#SelectExpandTestCustomers(Orders)", result["@odata.context"]);
+        }
+
+        [Fact]
+        public void ExplicitSelectInExpandHasPriorityToAutoSelect()
+        {
+            // Arrange
+            string uri = "/odata-autoselect/SelectExpandTestCustomers?$expand=Orders($select=ID)";
+
+            // Act
+            HttpResponseMessage response = GetResponse(uri, AcceptJsonFullMetadata);
+
+            // Assert
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            JObject result = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+            Console.WriteLine(result["@odata.context"]);
+            Assert.Equal("http://localhost/odata-autoselect/$metadata#SelectExpandTestCustomers(Orders(ID))", result["@odata.context"]);
         }
 
         [Theory]

--- a/test/UnitTest/System.Web.OData.Test/OData/SelectExpandTest.cs
+++ b/test/UnitTest/System.Web.OData.Test/OData/SelectExpandTest.cs
@@ -91,7 +91,6 @@ namespace System.Web.OData
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             JObject result = JObject.Parse(response.Content.ReadAsStringAsync().Result);
-            Console.WriteLine(result["@odata.context"]);
             Assert.Equal("http://localhost/odata-autoselect/$metadata#SelectExpandTestCustomers", result["@odata.context"]);
         }
 
@@ -109,7 +108,6 @@ namespace System.Web.OData
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             JObject result = JObject.Parse(response.Content.ReadAsStringAsync().Result);
-            Console.WriteLine(result["@odata.context"]);
             Assert.Equal("http://localhost/odata-autoselect/$metadata#SelectExpandTestCustomers(ID)", result["@odata.context"]);
         }
 
@@ -126,7 +124,6 @@ namespace System.Web.OData
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             JObject result = JObject.Parse(response.Content.ReadAsStringAsync().Result);
-            Console.WriteLine(result["@odata.context"]);
             Assert.Equal("http://localhost/odata-autoselect/$metadata#SelectExpandTestCustomers(Orders)", result["@odata.context"]);
         }
 
@@ -143,7 +140,6 @@ namespace System.Web.OData
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             JObject result = JObject.Parse(response.Content.ReadAsStringAsync().Result);
-            Console.WriteLine(result["@odata.context"]);
             Assert.Equal("http://localhost/odata-autoselect/$metadata#SelectExpandTestCustomers(Orders(ID))", result["@odata.context"]);
         }
 


### PR DESCRIPTION
Don't include all properties to @odata.context when entity level auto selected is used

Depends on https://github.com/kosinsky/odata.net/pull/4 